### PR TITLE
Prevent set password popup when hash exists

### DIFF
--- a/src/components/ui/WhiteboardPasswordModal.jsx
+++ b/src/components/ui/WhiteboardPasswordModal.jsx
@@ -15,6 +15,7 @@ const WhiteboardPasswordModal = ({ open, onClose }) => {
       setPassword('');
       setError('');
       setLoading(false);
+      // If password is already set, always use unlock mode
       setIsSetupMode(!isPasswordSet);
     }
   }, [open, isPasswordSet]);
@@ -126,17 +127,19 @@ const WhiteboardPasswordModal = ({ open, onClose }) => {
           </button>
         </form>
 
-        {/* Toggle between setup and unlock modes */}
-        <div className="text-center">
-          <button
-            type="button"
-            onClick={toggleMode}
-            className="text-sm text-primary hover:text-primary/80 transition-colors"
-            disabled={loading}
-          >
-            {isSetupMode ? 'Already have a password? Unlock instead' : 'Need to setup security? Setup instead'}
-          </button>
-        </div>
+        {/* Toggle between setup and unlock modes - only show when password is not set */}
+        {!isPasswordSet && (
+          <div className="text-center">
+            <button
+              type="button"
+              onClick={toggleMode}
+              className="text-sm text-primary hover:text-primary/80 transition-colors"
+              disabled={loading}
+            >
+              {isSetupMode ? 'Already have a password? Unlock instead' : 'Need to setup security? Setup instead'}
+            </button>
+          </div>
+        )}
 
         {/* Info about password */}
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">

--- a/src/context/WhiteboardContext.jsx
+++ b/src/context/WhiteboardContext.jsx
@@ -48,9 +48,23 @@ export const WhiteboardProvider = ({ children }) => {
   const [syncStatus, setSyncStatus] = useState('idle');
   const { token } = useAuth();
 
-  // Initialize IndexedDB on mount
+  // Initialize IndexedDB and check for existing password hash on mount
   useEffect(() => {
-    initDB().catch(console.error);
+    const initialize = async () => {
+      try {
+        await initDB();
+        
+        // Check if password hash already exists
+        const hashCheckResult = await checkPasswordHashExists();
+        if (hashCheckResult.success && hashCheckResult.exists) {
+          setIsPasswordSet(true);
+        }
+      } catch (error) {
+        console.error('Error initializing whiteboard:', error);
+      }
+    };
+    
+    initialize();
   }, []);
 
   // Setup sync manager callbacks


### PR DESCRIPTION
Initialize `isPasswordSet` state and hide the "set password" option when a password hash already exists in IndexedDB to ensure only the "unlock" popup is shown.

---
<a href="https://cursor.com/background-agent?bcId=bc-43a3fc84-4b60-4bd4-980c-8715c359bc18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43a3fc84-4b60-4bd4-980c-8715c359bc18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

