### PR TITLE
Fix indexedDB key range error

### DIFF
--- a/WHITEBOARD_IMPLEMENTATION.md
+++ b/WHITEBOARD_IMPLEMENTATION.md
@@ -25,7 +25,7 @@ The whiteboard has been completely refactored to implement the new ideas page lo
     properties: { x, y, z, color, height, width, empty },
     sendNoteId: -1,
     realNoteId: 452, // Set after sync
-    modifyFlag: true // Indicates need for sync
+    modifyFlag: 1 // Indicates need for sync (1 = true, 0 = false)
   }
   ```
 
@@ -45,7 +45,7 @@ The whiteboard has been completely refactored to implement the new ideas page lo
 - **1-Minute Interval**: Automatically syncs modified notes every minute
 - **Sync API**: `/api/v1/notes/user-notes` POST with modified notes
 - **Response Mapping**: Maps sendNoteId to realNoteId and updates IndexedDB
-- **Flag Management**: Sets modifyFlag to false after successful sync
+- **Flag Management**: Sets modifyFlag to 0 after successful sync
 
 ### 6. Search Integration
 - **Local Search**: Searches IndexedDB notes by content

--- a/src/context/WhiteboardContext.jsx
+++ b/src/context/WhiteboardContext.jsx
@@ -200,7 +200,7 @@ export const WhiteboardProvider = ({ children }) => {
           },
           sendNoteId: apiNote.noteId || apiNote.id,
           realNoteId: apiNote.noteId || apiNote.id,
-          modifyFlag: false
+          modifyFlag: 0
         };
 
         await storeNote(note);
@@ -261,7 +261,7 @@ export const WhiteboardProvider = ({ children }) => {
         },
         sendNoteId: negativeId,
         realNoteId: null,
-        modifyFlag: true
+        modifyFlag: 1
       };
 
       // Store in IndexedDB
@@ -295,7 +295,7 @@ export const WhiteboardProvider = ({ children }) => {
       // Update state
       setNotes(prev => prev.map(note =>
         note.noteId === noteId
-          ? { ...note, content, modifyFlag: true }
+          ? { ...note, content, modifyFlag: 1 }
           : note
       ));
 
@@ -324,7 +324,7 @@ export const WhiteboardProvider = ({ children }) => {
       // Update state
       setNotes(prev => prev.map(note =>
         note.noteId === noteId
-          ? { ...note, properties, modifyFlag: true }
+          ? { ...note, properties, modifyFlag: 1 }
           : note
       ));
 
@@ -346,10 +346,10 @@ export const WhiteboardProvider = ({ children }) => {
     try {
       // For negative IDs, just remove from IndexedDB
       if (noteId < 0) {
-        await updateNote(noteId, { isDeleted: true, modifyFlag: true });
+        await updateNote(noteId, { isDeleted: true, modifyFlag: 1 });
       } else {
         // For positive IDs, mark as deleted and sync will handle it
-        await updateNote(noteId, { isDeleted: true, modifyFlag: true });
+        await updateNote(noteId, { isDeleted: true, modifyFlag: 1 });
       }
 
       // Update state

--- a/src/utils/indexedDB.js
+++ b/src/utils/indexedDB.js
@@ -184,7 +184,7 @@ export const updateNote = async (noteId, updates) => {
           const updatedNote = { 
             ...existingNote, 
             ...updates, 
-            modifyFlag: true 
+            modifyFlag: 1 
           };
           
           const putRequest = store.put(updatedNote);
@@ -211,7 +211,7 @@ export const updateNote = async (noteId, updates) => {
   }
 };
 
-// Get notes with modifyFlag = true
+// Get notes with modifyFlag = 1
 export const getModifiedNotes = async () => {
   try {
     const db = await initDB();
@@ -220,7 +220,7 @@ export const getModifiedNotes = async () => {
     const index = store.index('modifyFlag');
     
     return new Promise((resolve, reject) => {
-      const request = index.getAll(IDBKeyRange.only(true)); 
+      const request = index.getAll(IDBKeyRange.only(1)); 
       
       request.onsuccess = () => {
         resolve({ success: true, notes: request.result });
@@ -259,7 +259,7 @@ export const updateNoteWithRealId = async (sendNoteId, realNoteId) => {
               noteId: realNoteId,
               sendNoteId: realNoteId,
               realNoteId: realNoteId,
-              modifyFlag: false
+              modifyFlag: 0
             };
             
             const putRequest = store.put(updatedNote);

--- a/src/utils/syncManager.js
+++ b/src/utils/syncManager.js
@@ -122,7 +122,7 @@ class SyncManager {
           updatedCount++;
         } else if (sendNoteId > 0) {
           // Update existing note to clear modifyFlag
-          await updateNote(sendNoteId, { modifyFlag: false });
+          await updateNote(sendNoteId, { modifyFlag: 0 });
           updatedCount++;
         }
       }

--- a/src/utils/whiteboardApi.js
+++ b/src/utils/whiteboardApi.js
@@ -203,7 +203,7 @@ export const syncNotes = async (token, notes) => {
     const data = await response.json();
     
     // Expected response format:
-    // [{ "sendNoteId": -1, "realNoteId": 452, "modifyFlag": false }, ...]
+    // [{ "sendNoteId": -1, "realNoteId": 452, "modifyFlag": 0 }, ...]
     return {
       success: true,
       syncResults: data


### PR DESCRIPTION
Convert IndexedDB `modifyFlag` from boolean to numeric (1/0) to fix `IDBKeyRange.only()` DataError.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ae900a9-6314-486e-9253-e751566f9769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ae900a9-6314-486e-9253-e751566f9769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

